### PR TITLE
Show the image term meta in the Rest API

### DIFF
--- a/includes/class-wp-term-meta-ui.php
+++ b/includes/class-wp-term-meta-ui.php
@@ -182,8 +182,13 @@ class WP_Term_Meta_UI {
 		register_meta(
 			'term',
 			$this->meta_key,
-			array( $this, 'sanitize_callback' ),
-			array( $this, 'auth_callback'     )
+			array(
+				'sanitize_callback' 	=> array( $this, 'sanitize_callback' ),
+				'auth_callback'		=> array( $this, 'auth_callback' ),
+				'show_in_rest'		=> apply_filters( "wp_term_image_show_in_rest", true ),
+				'single'		=> true,
+				'type'			=> 'integer',
+			)
 		);
 	}
 


### PR DESCRIPTION
Use the new register_meta "args" parameter to show the term image in the Rest API response.
Add a filter for the "show_in_rest" option.